### PR TITLE
Allow using Blitzloop with !JACK audio backends

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -9,6 +9,7 @@ Dependencies:
   libsndfile
   libsamplerate
   librubberband
+  portaudio
 
  Python modules/bindings:
   numpy
@@ -33,7 +34,8 @@ $ sudo apt-get install \
 	libsamplerate-dev \
 	librubberband-dev \
 	libffms2-dev \
-	libfreetype6-dev
+	libfreetype6-dev \
+  libportaudio-dev
 $ sudo easy_install freetype-py 3to2
 (ffms doesn't work with easy_install for some reason)
 $ wget https://bitbucket.org/spirit/ffms/downloads/ffms-0.3a2.tar.bz2

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ setup(
         Extension("_audio",
             ["_audio.pyx"],
             language="c++",
-            libraries=["jack", "samplerate", "sndfile", "rubberband"]
+            libraries=["jack", "samplerate", "sndfile", "rubberband",
+                       "portaudio"]
             )
     ],
     cmdclass={"build_ext": build_ext}


### PR DESCRIPTION
Heavily refactor _audio.pyx to isolate audio backend specific methods behind a
common interface. The interface is designed around the current feature set of
JACK, but in practice making other systems fit isn't too hard.

Add a PortAudio backend following this new interface. There is some haxx going
on with the timing because PortAudio -> ALSA -> Pulse -> ALSA loses some of the
timing information on its way (Pulse devs say it's because of ALSA's plugin
interface), but it seems to work decently enough...
