### PR TITLE
Basic config file functionality.

### DIFF
--- a/blitzloop/main.py
+++ b/blitzloop/main.py
@@ -17,23 +17,29 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 import os
-import sys
 
-from blitzloop import graphics, idlescreen, layout, mpvplayer, songlist, web
+from blitzloop import graphics, idlescreen, layout, mpvplayer, songlist, util, web
 from blitzloop._audio import *
 
 
-fullscreen = False
-if sys.argv[1] == "-fs":
-    sys.argv = sys.argv[1:]
-    fullscreen = True
+parser = util.get_argparser()
+parser.add_argument(
+    '--songdir', default=os.path.expanduser('~/.blitzloop/songs'),
+    help='directory with songs')
+parser.add_argument('--port', default=10111, help='port for the UI')
+parser.add_argument(
+    '--width', default=1024, help='width of blitzloop window (ignored in fs)')
+parser.add_argument(
+    '--height', default=768, help='height of blitzloop window (ignored in fs)')
+opts = util.get_opts()
 
-songs_dir = sys.argv[1]
-width = int(sys.argv[2])
-height = int(sys.argv[3])
+fullscreen = opts.fullscreen
+songs_dir = os.path.expanduser(opts.songdir)
+width = int(opts.width)
+height = int(opts.height)
 
 print("Loading song DB...")
-song_database = songlist.SongDatabase(sys.argv[1])
+song_database = songlist.SongDatabase(songs_dir)
 print("Done.")
 
 display = graphics.Display(width, height, fullscreen)
@@ -64,7 +70,7 @@ audio_config = AudioConfig()
 web.database = song_database
 web.queue = queue
 web.audio_config = audio_config
-server = web.ServerThread(host="0.0.0.0", port=10111, server="paste")
+server = web.ServerThread(host="0.0.0.0", port=opts.port, server="paste")
 server.start()
 
 idle_screen = idlescreen.IdleScreen(display)

--- a/blitzloop/play.py
+++ b/blitzloop/play.py
@@ -19,21 +19,22 @@
 import OpenGL.GL as gl
 import OpenGL.GLUT as glut
 import os
-import sys
 import time
 
-from blitzloop import graphics, layout, mpvplayer, song
+from blitzloop import graphics, layout, mpvplayer, song, util
 
 
-fullscreen = False
-if sys.argv[1] == "-fs":
-    sys.argv = sys.argv[1:]
-    fullscreen = True
+parser = util.get_argparser()
+parser.add_argument('songpath', help='path to the song file')
+parser.add_argument('offset', nargs='?', default=0, help='song offset')
+parser.add_argument('variant', nargs='?', default=0, help='song variant')
+opts = util.get_opts()
 
-s = song.Song(sys.argv[1])
+fullscreen = opts.fullscreen
+s = song.Song(opts.songpath)
 
-offset = float(sys.argv[2]) if len(sys.argv) >= 3 else 0
-variant = int(sys.argv[3]) if len(sys.argv) >= 4 else 0
+offset = float(opts.offset)
+variant = int(opts.variant)
 
 headstart = 0.3
 

--- a/blitzloop/util.py
+++ b/blitzloop/util.py
@@ -18,15 +18,30 @@
 
 import os
 import sys
+import configargparse
 
 
-# TODO: consider using pkgutil.get_data here?
 RESDIR = os.path.join(os.path.dirname(sys.modules[__name__].__file__), 'res')
 CFG = {
         'fontdir': os.path.join(RESDIR, 'fonts'),
         'gfxdir': os.path.join(RESDIR, 'gfx'),
         'webdir': os.path.join(RESDIR, 'web'),
 }
+
+def init_argparser():
+    configargparse.init_argument_parser(
+            default_config_files=['/etc/blitzloop/cfg', '~/.blitzloop/cfg'])
+    parser = configargparse.get_argument_parser()
+    parser.add_argument(
+        '--fullscreen', default=False, action='store_true',
+        help='run blitzloop fullscreen')
+
+def get_argparser():
+    return configargparse.get_argument_parser()
+
+def get_opts():
+    opts, unknown = get_argparser().parse_known_args()
+    return opts
 
 def get_res_path(t, fp):
     return os.path.join(CFG[t], fp)
@@ -45,3 +60,6 @@ def map_from(x, min, max):
 
 def map_to(x, min, max):
     return min + x * (max - min)
+
+
+init_argparser()

--- a/blitzloop/web.py
+++ b/blitzloop/web.py
@@ -257,5 +257,6 @@ class ServerThread(threading.Thread):
         bottle.run(*self.args, **self.kwargs)
 
 if __name__ == "__main__":
+    opts = util.get_opts()
     database = songlist.SongDatabase(sys.argv[1])
-    bottle.run(reloader=True, host="0.0.0.0", port=10111, server="paste")
+    bottle.run(reloader=True, host="0.0.0.0", port=opts.port, server="paste")

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -86,7 +86,7 @@ to finish the installation - it's only blitzloop itself that needs these flags.
 
 ### Add songs.
 Stories tell about ancient caches of existing blitzloop songs. Find one, or make
-your own songs.
+your own songs. By default, blitzloop expects songs in `~/.blitzloop/songs`.
 
 ### Sing!
 ```shell

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,11 @@
+# Configuration
+
+There's a couple of command line flags you can use with `blitzloop` - run
+`blitzloop --help` to see them. All of them can be overriden via one of two
+config files:
+
+ * `/etc/blitzloop/cfg`
+ * `~/.blitzloop/cfg`
+
+See [this file][example.cfg] for an example. You don't **need** a config file,
+if you're happy with defaults.

--- a/docs/example.cfg
+++ b/docs/example.cfg
@@ -1,0 +1,7 @@
+[blitzloop]
+# Where are the songs?
+songdir = /mnt/stash/fun/blitzloop/songs
+# Which port should UI be served at?
+port = 9099
+# Should blitzloop run in full screen mode?
+fullscreen

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         ],
         install_requires=[
             '3to2',
+            'ConfigArgParse',
             'Pillow',
             'bottle',
             'ffms',


### PR DESCRIPTION
Sane defaults in case of no config file or no option in a config file. Used argparse for cmdline handling, so now you can just run `blitzloop`. Isn't future nice? :D 

Obviously this is dependent on https://github.com/marcan/blitzloop/pull/10.