### PR TITLE
play.py as standalone blitzloop player, with fixed keyboard handling

### DIFF
--- a/blitzloop/main.py
+++ b/blitzloop/main.py
@@ -162,7 +162,7 @@ def main():
             yield i
 
 def key(k):
-    if k == '\033':
+    if k == b'\x1b':
         mpv.shutdown()
         audio.shutdown()
         os._exit(0)

--- a/blitzloop/mpvplayer.py
+++ b/blitzloop/mpvplayer.py
@@ -32,6 +32,7 @@ class Player(object):
         self.mpv.set_property("terminal", True)
         self.mpv.set_property("quiet", True)
         self.mpv.set_property("ao", "jack")
+        self.mpv.set_property("jack-autostart", "yes")
         self.mpv.set_property("af", "@pan:pan=2:[1,0,0,1],@rb:rubberband")
         self.mpv.set_property("video-sync", "display-vdrop")
         self.mpv.set_property("display-fps", 60)

--- a/blitzloop/play.py
+++ b/blitzloop/play.py
@@ -91,14 +91,14 @@ pause = False
 
 def key(k):
     global speed_i, pitch_i, vocals_i, pause
-    if k == '\033':
+    if k == b'\x1b':
         mpv.shutdown()
         os._exit(0)
-    if k == '[' and speed_i > -12:
+    if k == b'[' and speed_i > -12:
         speed_i -= 1
         print("Speed: %d" % speed_i)
         mpv.set_speed(2**(-speed_i/12.0))
-    elif k == ']' and speed_i < 12:
+    elif k == b']' and speed_i < 12:
         speed_i += 1
         print("Speed: %d" % speed_i)
         mpv.set_speed(2**(-speed_i/12.0))
@@ -110,11 +110,11 @@ def key(k):
         pitch_i -= 1
         print("Pitch: %d" % pitch_i)
         mpv.set_pitch(2**(pitch_i/12.0))
-    elif k == '+' and vocals_i < 30:
+    elif k == b'+' and vocals_i < 30:
         vocals_i += 1
         print("Vocals: %d" % vocals_i)
         mpv.set_channel(0, vocals_i/10.0)
-    elif k == '-' and vocals_i > 0:
+    elif k == b'-' and vocals_i > 0:
         vocals_i -= 1
         print("Vocals: %d" % vocals_i)
         mpv.set_channel(0, vocals_i/10.0)
@@ -122,7 +122,7 @@ def key(k):
         mpv.seek(-10)
     elif k == glut.GLUT_KEY_RIGHT:
         mpv.seek(10)
-    elif k == ' ':
+    elif k == b' ':
         pause = not pause
         t = time.time()
         mpv.set_pause(pause)

--- a/blitzloop/play.py
+++ b/blitzloop/play.py
@@ -25,6 +25,9 @@ from blitzloop import graphics, layout, mpvplayer, song, util
 
 
 parser = util.get_argparser()
+parser.add_argument(
+    '--show-timings', dest='st', action='store_true',
+    help='show mpv timings')
 parser.add_argument('songpath', help='path to the song file')
 parser.add_argument('offset', nargs='?', default=0, help='song offset')
 parser.add_argument('variant', nargs='?', default=0, help='song variant')
@@ -77,7 +80,8 @@ def render():
         renderer.draw(song_time + headstart * 2**(speed_i/12.0), layout)
         yield None
         t2 = time.time()
-        print("T:%7.3f/%7.3f B:%7.3f FPS:%.2f draw:%.3f" % (song_time, mpv.duration, s.timing.time2beat(song_time), (1.0/(t2-t)), dt))
+        if opts.st:
+            print("T:%7.3f/%7.3f B:%7.3f FPS:%.2f draw:%.3f" % (song_time, mpv.duration, s.timing.time2beat(song_time), (1.0/(t2-t)), dt))
         t = t2
         mpv.flip()
     mpv.shutdown()

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -9,3 +9,10 @@ config files:
 
 See [this file][example.cfg] for an example. You don't **need** a config file,
 if you're happy with defaults.
+
+# One shot
+
+You can use `blitzloop-single` to quickly play a particular song. This is useful
+for song-testing, and when you're really desperate for a quick karaoke fix. You
+need to point `blitzloop-single` at a specific `song.txt` file. See
+`blitzloop-single`'s help for more details.

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         entry_points={
             'console_scripts': [
                 'blitzloop = blitzloop.main',
+                'blitzloop-single = blitzloop.play',
             ]
         },
         setup_requires=[


### PR DESCRIPTION
Type of the variable used to pass the key pressed has changed from `str` to `bytes`.

Please merge after https://github.com/marcan/blitzloop/pull/11.