### PR TITLE
Fix a few things to make blitzloop run on Windows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 *~
 .eggs
 blitzloop/_audio*so
+blitzloop/_audio*pyd
 build

--- a/blitzloop/util.py
+++ b/blitzloop/util.py
@@ -17,6 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 import os
+import os.path
 import sys
 import configargparse
 
@@ -30,7 +31,7 @@ CFG = {
 
 def init_argparser():
     config_home = os.getenv('XDG_CONFIG_HOME', '~/.config')
-    home = os.getenv('HOME')
+    home = os.path.expanduser('~')
     if config_home.startswith(home):
         config_home = '~' + config_home[len(home):]
     config_file = os.path.join(config_home, 'blitzloop', 'blitzloop.conf')


### PR DESCRIPTION
The hard part is in the whole setup (getting a non-crashing Jack client
library, making Cython not crash, etc.). These are the only code changes
required to make Blitzloop run on Windows 10 x64.